### PR TITLE
Exclude potential `.git` suffix from repo path.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
  "dirs",
  "env_logger",
  "log",
+ "test-case",
  "url",
 ]
 
@@ -375,6 +376,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-case"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07aea929e9488998b64adc414c29fe5620398f01c2e3f58164122b17e567a6d5"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c95968eedc6fc4f5c21920e0f4264f78ec5e4c56bb394f319becc1a5830b3e54"
+dependencies = [
+ "cfg-if",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ version = "3.1.18"
 features = [
   "derive"
 ]
+
+[dev-dependencies]
+test-case = "2.2.1"

--- a/src/repopath.rs
+++ b/src/repopath.rs
@@ -8,7 +8,13 @@ where
 {
     let mut path = basedir.as_ref().to_path_buf();
     path.push(url.domain());
-    for segment in url.path_segments() {
+    let mut segments = url.path_segments().peekable();
+    while let Some(segment) = segments.next() {
+        let segment = if segments.peek().is_none() {
+            segment.strip_suffix(".git").unwrap_or(segment)
+        } else {
+            segment
+        };
         path.push(segment);
     }
     path

--- a/src/repopath.rs
+++ b/src/repopath.rs
@@ -13,3 +13,6 @@ where
     }
     path
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/repopath/tests.rs
+++ b/src/repopath/tests.rs
@@ -1,0 +1,14 @@
+use test_case::test_case;
+
+#[test_case("https://repos.net/a/b/c" => "FAKE/src/repos.net/a/b/c".to_string())]
+#[test_case("https://repos.net/a/b/c.git" => "FAKE/src/repos.net/a/b/c".to_string())]
+fn test(url: &str) -> String {
+    use crate::{get_repo_path, Url};
+    use std::path::Path;
+    use std::str::FromStr;
+
+    let basedir = Path::new("FAKE/src");
+    let url = Url::from_str(url).unwrap();
+    let repopath = get_repo_path(basedir, &url);
+    repopath.display().to_string()
+}


### PR DESCRIPTION
This makes behavior coherent with `git`.