### PR TITLE
Git-style pseudo-url support

### DIFF
--- a/src/url.rs
+++ b/src/url.rs
@@ -33,7 +33,21 @@ impl FromStr for Url {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let u = Url(url::Url::from_str(s)?);
+        // Patch the input string from a "git-style" pseudo-url to a proper url.
+        //
+        // A git-style url is `user@host:path` which is patched to `ssh://user@host/path`
+        let patched = s
+            .split_once(':')
+            .map(|(prefix, suffix)| {
+                if suffix.starts_with("//") {
+                    s.to_string()
+                } else {
+                    format!("ssh://{prefix}/{suffix}")
+                }
+            })
+            .unwrap_or(s.to_string());
+
+        let u = Url(url::Url::from_str(&patched)?);
         u.try_domain()?;
         Ok(u)
     }

--- a/src/url.rs
+++ b/src/url.rs
@@ -67,3 +67,6 @@ impl<'a> Iterator for PathSegments<'a> {
         self.0.as_mut().and_then(|it| it.next())
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/url/tests.rs
+++ b/src/url/tests.rs
@@ -4,9 +4,14 @@ use test_case::test_case;
 #[test_case("https://github.com/nathan-at-least/git-clone-canonical", "github.com", &["nathan-at-least", "git-clone-canonical"])]
 #[test_case("https://github.com/nathan-at-least/git-clone-canonical.git", "github.com", &["nathan-at-least", "git-clone-canonical.git"])]
 #[test_case("git@github.com:nathan-at-least/git-clone-canonical.git", "github.com", &["nathan-at-least", "git-clone-canonical.git"])]
-fn parse_to_path_segments(input: &str, expected_domain: &str, expected_path_segments: &[&str]) {
-    let url: Url = input.parse().unwrap();
+fn parse_to_path_segments(
+    input: &str,
+    expected_domain: &str,
+    expected_path_segments: &[&str],
+) -> Result<(), <Url as std::str::FromStr>::Err> {
+    let url: Url = input.parse()?;
     assert_eq!(url.domain(), expected_domain);
     let segments: Vec<&str> = url.path_segments().collect();
     assert_eq!(segments.as_slice(), expected_path_segments);
+    Ok(())
 }

--- a/src/url/tests.rs
+++ b/src/url/tests.rs
@@ -1,0 +1,12 @@
+use crate::Url;
+use test_case::test_case;
+
+#[test_case("https://github.com/nathan-at-least/git-clone-canonical", "github.com", &["nathan-at-least", "git-clone-canonical"])]
+#[test_case("https://github.com/nathan-at-least/git-clone-canonical.git", "github.com", &["nathan-at-least", "git-clone-canonical.git"])]
+#[test_case("git@github.com:nathan-at-least/git-clone-canonical.git", "github.com", &["nathan-at-least", "git-clone-canonical.git"])]
+fn parse_to_path_segments(input: &str, expected_domain: &str, expected_path_segments: &[&str]) {
+    let url: Url = input.parse().unwrap();
+    assert_eq!(url.domain(), expected_domain);
+    let segments: Vec<&str> = url.path_segments().collect();
+    assert_eq!(segments.as_slice(), expected_path_segments);
+}


### PR DESCRIPTION
Git uses pseudo-urls like `git@github.com:nathan-at-least/git-clone-canonical.git` which are rejected by the `url` crate (since they aren't conformant urls).

This PR includes a "patch" when parsing `crate::Url` to translate git-like pseudo-urls into proper `ssh://` urls before passing to the `url` crate parser, enabling those to be passed as inputs to the executable successfully.